### PR TITLE
Update account-factory.md - missing SSO permission

### DIFF
--- a/doc_source/account-factory.md
+++ b/doc_source/account-factory.md
@@ -50,6 +50,7 @@ To configure Account Factory accounts in a more automated way, you can create La
                 "sso:ProvisionApplicationProfileForAWSAccountInstance",
                 "sso:ProvisionSAMLProvider",
                 "sso:ListProfileAssociations",
+                "sso:DescribeRegisteredRegions",
                 "sso-directory:ListMembersInGroup",
                 "sso-directory:AddMemberToGroup",
                 "sso-directory:SearchGroups",


### PR DESCRIPTION
"sso:DescribeRegisteredRegions" permission is missing. this required by Service Catalog to provision an account automatically.

*Issue #, if available:*
AccessDeniedException User: arn:aws:iam::------:user/ct-account-provision is not authorized to perform: sso:DescribeRegisteredRegions

*Description of changes:*
Adding permission of "sso:DescribeRegisteredRegions" to the account factory policy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
