### PR TITLE
Link to current list of region-to-service mappings

### DIFF
--- a/doc_source/disaster-recovery-resiliency.md
+++ b/doc_source/disaster-recovery-resiliency.md
@@ -4,12 +4,7 @@ The AWS global infrastructure is built around AWS Regions and Availability Zones
 
  AWS Regions provide multiple physically separated and isolated Availability Zones, which are connected by means of low\-latency, high\-throughput, and highly redundant networking\. Availability Zones allow you to design and operate applications and databases that automatically fail over between Availability Zones without interruption\. Availability Zones are more highly available, fault tolerant, and scalable than traditional single or multiple data center infrastructures\.
 
-AWS Control Tower is available in these AWS Regions:
-+ US East \(N\. Virginia\)
-+ US East \(Ohio\)
-+ US West \(Oregon\)
-+ Europe \(Ireland\)
-+ Asia Pacific \(Sydney\)
+AWS Control Tower is available in several AWS Regions. For a current list of regions, see the [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/) list.
 
 Your *home region* is defined as the AWS Region in which your landing zone was set up\.
 


### PR DESCRIPTION
Since Control Tower launched, support has rolled out to additional AWS regions.

*Issue #, if available:* https://github.com/awsdocs/aws-control-tower-guide/issues/20

*Description of changes:*

Rather than listing the regions where Control Tower is available, hyperlink to a page where readers can (manually) check if a region provides support.

As far as I know, this documentation repo does not have a way to automate keeping that list up to date.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
