### PR TITLE
Add root user requirement and link for changing account name

### DIFF
--- a/doc_source/external-resources.md
+++ b/doc_source/external-resources.md
@@ -46,7 +46,7 @@ AWS Control Tower displays the names of OUs in the AWS Control Tower dashboard a
 
 **Renaming an enrolled account**
 
-Each AWS account has a display name that can be changed in the AWS Billing and Cost Management console\. When you rename an account that's enrolled in AWS Control Tower, the name change is automatically reflected in AWS Control Tower\. 
+Each AWS account has a display name that can be changed by the account's root user in the AWS Billing and Cost Management console\. When you rename an account that's enrolled in AWS Control Tower, the name change is automatically reflected in AWS Control Tower\. For more information about changing an account's name, see [Managing an AWS account](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/manage-account-payment.html#manage-account-payment-edit-user-name) in the AWS Billing User Guide\.
 
 ## Deleting the Security OU<a name="delete-security-ou"></a>
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Added clarification that you need to be signed in as the root user to change the account name and added a link to the documentation.

Wasn't sure which of the following is the best link, but went with the first:

* [Managing an AWS account](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/manage-account-payment.html) in the AWS Billing User Guide
* [Updating the root user](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-update-root-user.html) in the AWS Account Management Reference Guide


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
