### PR TITLE
Add API authorization details to Terraform Cloud and Enterprise

### DIFF
--- a/doc_source/version-supported.md
+++ b/doc_source/version-supported.md
@@ -15,7 +15,7 @@ AFT supports three Terraform distributions\.
 
 These distributions are explained in the sections that follow\. You must provide the Terraform distribution of your choice as an input parameter during the AFT bootstrap process\. See [Deploy AWS Control Tower Account Factory for Terraform \(AFT\)](aft-getting-started.md) for more information on AFT deployment and input parameters\.
 
-When using Terraform Cloud or Terraform Enterprise, ensure that the [API token] you are using for `terraform_token` is a User or Team API Token - an Organization Token is not supported for all [required APIs](https://www.terraform.io/cloud-docs/api-docs/configuration-versions). Avoid checking-in this value to your to VCS by using a [terraform variable](https://www.terraform.io/cloud-docs/workspaces/variables/managing-variables)
+When using Terraform Cloud or Terraform Enterprise, ensure that the [API token](https://www.terraform.io/cloud-docs/users-teams-organizations/api-tokens) you are using for `terraform_token` is a User or Team API Token - an Organization Token is not supported for all [required APIs](https://www.terraform.io/cloud-docs/api-docs/configuration-versions). Avoid checking-in this value to your to VCS by using a [terraform variable](https://www.terraform.io/cloud-docs/workspaces/variables/managing-variables).
 
 ```
   # Sensitive variable managed in Terraform Cloud:

--- a/doc_source/version-supported.md
+++ b/doc_source/version-supported.md
@@ -11,9 +11,16 @@ version_number = "0.15.1"
 AFT supports three Terraform distributions\.
 + Terraform OSS
 + Terraform Cloud
-+  Terraform Enterprise
++ Terraform Enterprise
 
 These distributions are explained in the sections that follow\. You must provide the Terraform distribution of your choice as an input parameter during the AFT bootstrap process\. See [Deploy AWS Control Tower Account Factory for Terraform \(AFT\)](aft-getting-started.md) for more information on AFT deployment and input parameters\.
+
+When using Terraform Cloud or Terraform Enterprise, ensure that the [API token] you are using for `terraform_token` is a User or Team API Token - an Organization Token is not supported for all [required APIs](https://www.terraform.io/cloud-docs/api-docs/configuration-versions). Avoid checking-in this value to your to VCS by using a [terraform variable](https://www.terraform.io/cloud-docs/workspaces/variables/managing-variables)
+
+```
+  # Sensitive variable managed in Terraform Cloud:
+  terraform_token = var.terraform_cloud_token
+```
 
 ### Terraform Open Source Software \(Terraform OSS\)<a name="terraform-oss"></a>
 
@@ -48,8 +55,8 @@ When you select Terraform Cloud as your distribution, AFT creates workspaces for
 The resulting Terraform state configuration is managed by Terraform Cloud\.
 
 For selecting Terraform Cloud as your distribution, provide the following input parameters:
-+  `distribution = "tfc"` 
-+ `terraform_token` – This parameter contains the value of your Terraform Cloud token\. AFT marks its value as sensitive and stores it as a secure string in the SSM parameter store, in the AFT management account\. We recommend that you periodically rotate the value of the Terraform token, according to your company's security policies and compliance guidelines\.
++  `distribution = "tfc"`
++ `terraform_token` – This parameter contains the value of your Terraform Cloud token\. AFT marks its value as sensitive and stores it as a secure string in the SSM parameter store, in the AFT management account\. We recommend that you periodically rotate the value of the Terraform token, according to your company's security policies and compliance guidelines\. Terraform token should be a User or Team level API token, Organization tokens are not supported.
 + `terraform_org_name` – This parameter contains the name of your Terraform Cloud organization\.
 
 See [the Terraform documentation](https://www.terraform.io/docs/cloud/index.html) to learn more about how to set up Terraform Cloud\.
@@ -65,8 +72,8 @@ When you select Terraform Enterprise as your distribution, AFT creates workspace
 The resulting Terraform state configuration is managed by your Terraform Enterprise setup\.
 
 To select Terraform Enterprise as your distribution, provide the following input parameters:
-+  `distribution = "tfe"` 
-+ `terraform_token` – This parameter contains the value of your Terraform Enterprise token\. AFT marks its value as sensitive and stores it as a secure string in the SSM parameter store, in the AFT management account\. We recommend that you periodically rotate the value of the Terraform token, according to your company's security policies and compliance guidelines\.
++  `distribution = "tfe"`
++ `terraform_token` – This parameter contains the value of your Terraform Enterprise token\. AFT marks its value as sensitive and stores it as a secure string in the SSM parameter store, in the AFT management account\. We recommend that you periodically rotate the value of the Terraform token, according to your company's security policies and compliance guidelines\. Terraform token should be a User or Team level API token, Organization tokens are not supported.
 + `terraform_org_name` – This parameter contains the name of your Terraform Enterprise organization\.
 + `terraform_api_endpoint` – This parameter contains the URL of your Terraform Enterprise environment\. The value of this parameter must be in the format:
 


### PR DESCRIPTION
When using the [terraform cloud example with an api token](https://github.com/aws-ia/terraform-aws-control_tower_account_factory/blob/1.1.1/examples/githubenterprise+tf_cloud/main.tf#L19), running AWS CodePipeline job `ct-aft-account-provisioning-customizations` in the AFT Management account results in generic output from Terraform Cloud:

```
Successfully created workspace ct-aft-account-provisioning-customizations with ID <terraform-cloud-workspace-id>
Successfully placed AWS credentials on workspace for <arn>
Handling errors: [{'status': '404', 'title': 'not found'}]

Traceback (most recent call last):
  File "/codebuild/output/src662193728/src/aws-aft-core-framework/sources/scripts/workspace_manager.py", line 272, in <module>
    setup_and_run_workspace(
  File "/codebuild/output/src662193728/src/aws-aft-core-framework/sources/scripts/workspace_manager.py", line 19, in setup_and_run_workspace
    run_id = stage_run(workspace_id, assume_role_arn, role_session_name, api_token)
  File "/codebuild/output/src662193728/src/aws-aft-core-framework/sources/scripts/workspace_manager.py", line 45, in stage_run
    cv_id, upload_url = terraform.create_configuration_version(workspace_id, api_token)
  File "/codebuild/output/src662193728/src/aws-aft-core-framework/sources/scripts/terraform_client.py", line 71, in create_configuration_version
    response = __post(endpoint, headers, payload)
  File "/codebuild/output/src662193728/src/aws-aft-core-framework/sources/scripts/terraform_client.py", line 212, in __post
    __handle_errors(response)
  File "/codebuild/output/src662193728/src/aws-aft-core-framework/sources/scripts/terraform_client.py", line 250, in __handle_errors
    raise ClientError(status=error["status"], message=error["title"])
terraform_client.ClientError: not found
```

This pull request documents the issue to provide visibility to HashiCorp's specification for [Configuration Versions API](https://www.terraform.io/cloud-docs/api-docs/configuration-versions). 

> Note: This endpoint cannot be accessed with organization tokens. You must access it with a user token or team token.

The error message could be updated to inform the user, but it may be too loosely defined to consider all HTTP 404 responses from the endpoint to be only this problem. In many cases though, [they use 404 to represent unauthorized access](https://www.terraform.io/cloud-docs/api-docs/oauth-tokens):

> OAuth Token not found or user unauthorized to perform action

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.