### PR TITLE
Change reference from parameter to policy file

### DIFF
--- a/doc_source/cfcn-byo-cfn-stacksets.md
+++ b/doc_source/cfcn-byo-cfn-stacksets.md
@@ -111,7 +111,7 @@ resources:
 
 When you update the folder structure, you can include all supporting AWS CloudFormation template files and SCP policy files that are in the manifest file\. Verify that the file paths match what is provided in the manifest file\. 
 + A *template* file contains the AWS resources to be deployed in OUs and accounts\.
-+ A *parameter* file contains the input parameters used in the template file\.
++ A *policy* file contains the SCP policy to be deployed in OUs and accounts\.
 
 The following example shows the folder structure for the sample manifest file created in [Step 1](#cfcn-byo-cfn-stacksets-step-1)\.
 


### PR DESCRIPTION
The example uses a policy file instead of a parameter file, and therefore the reference should be a policy file

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
