### PR TITLE
Clarify `enable-root-mfa`

### DIFF
--- a/doc_source/strongly-recommended-controls.md
+++ b/doc_source/strongly-recommended-controls.md
@@ -231,7 +231,7 @@ Resources:
 
 ## Detect Whether MFA for the Root User is Enabled<a name="enable-root-mfa"></a>
 
-This control detects whether multi\-factor authentication \(MFA\) is enabled for the root user of the management account\. MFA reduces vulnerability risks from weak authentication by requiring an additional authentication code after the user name and password are successful\. This control does not change the status of the account\. This is a detective control with strongly recommended guidance\. By default, this control is not enabled\.
+This control detects whether multi\-factor authentication \(MFA\) is enabled for the root user\. MFA reduces vulnerability risks from weak authentication by requiring an additional authentication code after the user name and password are successful\. This control does not change the status of the account\. This is a detective control with strongly recommended guidance\. By default, this control is not enabled\.
 
 The artifact for this control is the following AWS Config rule\.
 


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

The `enable-root-mfa` control in Control Tower does *not* apply to the management account (as you cannot select the root OU to apply the control from within Control Tower). You must manually enable AWS Config on your management account and then select the built-in `root-account-mfa-enabled` rule inside the AWS Config console to get this detective control applied to the management account.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
