### PR TITLE
Update AFT account removal to reflect AFT 1.8.0

### DIFF
--- a/doc_source/aft-remove-account.md
+++ b/doc_source/aft-remove-account.md
@@ -11,25 +11,14 @@ Removing an account from the AFT pipeline is irreversible\. It can result in a l
 
 In the `git` repository where you store account requests, delete the account request for the account you intend to remove from AFT\.
 
-**Step 2: Delete the account customizations pipeline**
-
-In the AFT management account, delete the AWS CodePipeline for the account you intend to remove from AFT\. This pipeline has the account ID as the prefix in its name\. 
-
-**Step 3: Delete the Terraform workspace \(For Terraform Cloud and Terraform Enterprise customers only\)**
+**Step 2: Delete the Terraform workspace \(For Terraform Cloud and Terraform Enterprise customers only\)**
 
 Delete the global customizations and account customizations workspaces for the account you intend to remove from AFT\. 
 
-**Step 4: Delete the Terraform state from the Amazon S3 backend**
+**Step 3: Delete the Terraform state from the Amazon S3 backend**
 
 In the AFT management account, delete all relevant folders inside Amazon S3 buckets for the account you intend to remove from AFT\. In the examples that follow, replace the placeholder number `012345678901` with the AFT management account ID number\.
 
 If you chose Terraform OSS, you will find 3 folders for each account \(related to customizations pipeline state, global and account customizations state\) in the `aft-backend-012345678901-primary-region` and `aft-backend-012345678901-secondary-region` Amazon S3 buckets\.
 
 If you chose Terraform Cloud or Terraform Enterprise, you will find a folder for each account \(related to customizations pipeline state\) in the `aft-backend-012345678901-primary-region` and `aft-backend-012345678901-secondary-region` S3 buckets\. 
-
-**Step 5: Delete account metadata**
-
-In the AFT management account, delete the account\-related metadata for the account you intend to remove from AFT\. This metadata is stored in the parameter `aft-request-metadata` in the DynamoDB table\.
-
-**Note**  
-AFT uses this metadata as input to invoke downstream stages in the AFT pipeline, such as the AFT account provisioning framework and customizations, and for global and account customizations\.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* The [AFT 1.8.0 release](https://github.com/aws-ia/terraform-aws-control_tower_account_factory/releases/tag/1.8.0) (released last week 🙂) now automates some of the cleanup tasks that previously required manual intervention - specifically:

 - (step 2) deleting the account customizations pipeline; and,
 - (step 5) deleting the account metadata.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
