### PR TITLE
Removing obsolete CloudWatch log groups

### DIFF
--- a/doc_source/how-control-tower-works.md
+++ b/doc_source/how-control-tower-works.md
@@ -69,7 +69,7 @@ When you set up your landing zone, the following AWS resources are created withi
 | AWS Config | AWS Config Rules | AWSControlTower\_AWS\-GR\_AUDIT\_BUCKET\_PUBLIC\_READ\_PROHIBITED AWSControlTower\_AWS\-GR\_AUDIT\_BUCKET\_PUBLIC\_WRITE\_PROHIBIT | 
 | AWS CloudTrail | Trails | aws\-controltower\-BaselineCloudTrail | 
 | Amazon CloudWatch | CloudWatch Event Rules | aws\-controltower\-ConfigComplianceChangeEventRule | 
-| Amazon CloudWatch | CloudWatch Logs | aws\-controltower/CloudTrailLogs /aws/lambda/aws\-controltower\-NotificationForwarder | 
+| Amazon CloudWatch | CloudWatch Logs | /aws/lambda/aws\-controltower\-NotificationForwarder | 
 | AWS Identity and Access Management | Roles | aws\-controltower\-AdministratorExecutionRole aws\-controltower\-CloudWatchLogsRole aws\-controltower\-ConfigRecorderRole aws\-controltower\-ForwardSnsNotificationRole aws\-controltower\-ReadOnlyExecutionRole AWSControlTowerExecution | 
 | AWS Identity and Access Management | Policies | AWSControlTowerServiceRolePolicy | 
 | Amazon Simple Notification Service | Topics | aws\-controltower\-SecurityNotifications | 
@@ -91,7 +91,7 @@ When you set up your landing zone, the following AWS resources are created withi
 | AWS Config | AWS Config Rules | AWSControlTower\_AWS\-GR\_AUDIT\_BUCKET\_PUBLIC\_READ\_PROHIBITED AWSControlTower\_AWS\-GR\_AUDIT\_BUCKET\_PUBLIC\_WRITE\_PROHIBITED | 
 | AWS CloudTrail | Trail | aws\-controltower\-BaselineCloudTrail | 
 | Amazon CloudWatch | CloudWatch Event Rules | aws\-controltower\-ConfigComplianceChangeEventRule | 
-| Amazon CloudWatch | CloudWatch Logs | aws\-controltower/CloudTrailLogs /aws/lambda/aws\-controltower\-NotificationForwarder | 
+| Amazon CloudWatch | CloudWatch Logs | /aws/lambda/aws\-controltower\-NotificationForwarder | 
 | AWS Identity and Access Management | Roles | aws\-controltower\-AdministratorExecutionRole aws\-controltower\-CloudWatchLogsRole aws\-controltower\-ConfigRecorderRole aws\-controltower\-ForwardSnsNotificationRole aws\-controltower\-ReadOnlyExecutionRole aws\-controltower\-AuditAdministratorRole aws\-controltower\-AuditReadOnlyRole AWSControlTowerExecution | 
 | AWS Identity and Access Management | Policies | AWSControlTowerServiceRolePolicy | 
 | Amazon Simple Notification Service | Topics | aws\-controltower\-AggregateSecurityNotifications aws\-controltower\-AllConfigNotifications aws\-controltower\-SecurityNotifications | 


### PR DESCRIPTION
As per https://docs.aws.amazon.com/controltower/latest/userguide/2022-all.html#version-3.0 this AWS CloudWatch log group is removed from member accounts and now exists only in the management account.
I've removed them from the Log Archive and Audit account resource tables so they don't cause confusion.