### PR TITLE
Cloudtrail Source Identfier changed in Control Tower

### DIFF
--- a/doc_source/strongly-recommended-controls.md
+++ b/doc_source/strongly-recommended-controls.md
@@ -504,5 +504,5 @@ AWSTemplateFormatVersion: 2010-09-09
 	       Description: Detects whether an account has AWS CloudTrail or CloudTrail Lake enabled. The rule is NON_COMPLIANT if either CloudTrail or CloudTrail Lake is not enabled in an account.
 	       Source:
 	         Owner: AWS
-	         SourceIdentifier: CLOUD_TRAIL_ENABLED
+	         SourceIdentifier: CLOUDTRAIL_ENABLED_ON_MEMBER_ACCOUNTS
 ```


### PR DESCRIPTION
There is a new name in Control Tower for this control. So the Control Identifier is need to be changed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
